### PR TITLE
Added properties stroke-width and color.

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ var path    = require('path');
 var postcss = require('postcss');
 var xmldoc  = require('xmldoc');
 
-var matchProp = /^(fill|stroke|stroke-width|color)$/;
+var matchProp = /^(fill|stroke|stroke-width|color|width|height)$/;
 var matchURL  = /(^|\s)url\(.+\.svg#.+\)(\s|$)/;
 
 module.exports = postcss.plugin('postcss-svg-fragments', function (opts) {

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ var path    = require('path');
 var postcss = require('postcss');
 var xmldoc  = require('xmldoc');
 
-var matchProp = /^(fill|stroke)$/;
+var matchProp = /^(fill|stroke|stroke-width|color)$/;
 var matchURL  = /(^|\s)url\(.+\.svg#.+\)(\s|$)/;
 
 module.exports = postcss.plugin('postcss-svg-fragments', function (opts) {


### PR DESCRIPTION
Default stroke width is too thin, but with a higher stroke-width value and combined with a transparent fill, you can make outline versions of the same icon.

Passing a color value will be used in fill="currentColor" now to create dual colored SVGs as svg backgrounds or as Content in pseudo elements. One can use Gulp Cheerio to target a specific "accent" ID labeled by a design program in each of the SVGs to append fill="currentColor" to the appropriate SVG path. Tested and working.